### PR TITLE
ci: add fasthep-flow validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,83 @@
+name: Ecosystem Validation
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/validation.yml"
+      - "pyproject.toml"
+      - "src/**"
+      - "tests/**"
+  push:
+    branches:
+      - main
+    tags:
+      - "20*.*.*"
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "3"
+
+jobs:
+  fasthep-flow:
+    name: Validate fasthep-flow integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install FAST-HEP basic validation set
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[basic,test]"
+
+      - name: Run package tests
+        run: python -m pytest
+
+      - name: Write validation report
+        run: |
+          mkdir -p validation-reports
+          python - <<'PY'
+          from __future__ import annotations
+
+          import importlib.metadata as metadata
+          import json
+          from pathlib import Path
+
+          import fasthep
+          import hepflow
+
+          report = {
+              "package": "fasthep",
+              "fasthep_version": fasthep.__version__,
+              "fasthep_flow_distribution": metadata.version("fasthep-flow"),
+              "hepflow_module": hepflow.__name__,
+          }
+
+          Path("validation-reports/fasthep-flow.json").write_text(
+              json.dumps(report, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload validation report
+        uses: actions/upload-artifact@v7
+        with:
+          name: fasthep-flow-validation
+          path: validation-reports/fasthep-flow.json
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Adds a first ecosystem validation workflow for `fasthep-flow`, wired to PRs, pushes to `main`, release-style tags, published releases, and manual dispatch. The job installs `fasthep` with the `basic` and `test` extras, runs the package tests, imports the `hepflow` module provided by `fasthep-flow`, and uploads a JSON validation report artifact.

Closes #14

## Validation

- `.venv/bin/python -m pytest`
- Ran the workflow report script locally after `pip install -e ".[basic,test]"`; it imported `fasthep` and `hepflow` and wrote `validation-reports/fasthep-flow.json`.
- `git diff --check -- .github/workflows/validation.yml`

## AI-assisted contribution

Created with OpenAI Codex and manually reviewed. The workflow design was narrowed to an in-repo validation job because cross-repository workflow dispatch would require upstream permissions or secrets.
